### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ sourceSets {
 repositories {
     jcenter()
     mavenCentral()
-    maven { url 'http://repo.jenkins-ci.org/releases/' }
+    maven { url 'https://repo.jenkins-ci.org/releases/' }
 }
 
 dependencies {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://www.catosplace.net/blog/2015/02/11/running-jenkins-in-docker-containers/ (200) with 1 occurrences could not be migrated:  
   ([https](https://www.catosplace.net/blog/2015/02/11/running-jenkins-in-docker-containers/) result ConnectTimeoutException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://repo.jenkins-ci.org/releases/ with 1 occurrences migrated to:  
  https://repo.jenkins-ci.org/releases/ ([https](https://repo.jenkins-ci.org/releases/) result 200).