### PR TITLE
URL Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 *.war
 *.ear
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# virtual machine crash logs, see https://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
 .gradle

--- a/README.adoc
+++ b/README.adoc
@@ -69,7 +69,7 @@ initializeAndStartScst - Removes unnecessary code for SCST and starts Jenkins
 ```
 
 Assuming that you've just created a repo in your organization to host your custom App Staters.
-Let's assume that the repo is present at `http://foo.com/myrepo` then
+Let's assume that the repo is present at `http://www.foo.com/myrepo` then
 it's enough for you to do the following steps.
 
 [source]
@@ -77,9 +77,9 @@ it's enough for you to do the following steps.
 $ git clone https://github.com/spring-io/build-scripts
 $ cd build-scripts
 $ git remote remove origin
-$ git remote add origin http://foo.com/myrepo
+$ git remote add origin http://www.foo.com/myrepo
 $ git remote add upstream https://github.com/spring-io/build-scripts
-$ ./gradlew initializeAndStartScst -PrepoUrl=http://foo.com/myrepo
+$ ./gradlew initializeAndStartScst -PrepoUrl=http://www.foo.com/myrepo
 $ # alter the code in whatever way you need
 $ git add .
 $ git commit -m "Initialized App Starters for new repo"


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://foo.com/myrepo (301) with 3 occurrences could not be migrated:  
   ([https](https://foo.com/myrepo) result SSLHandshakeException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.java.com/en/download/help/error_hotspot.xml with 1 occurrences migrated to:  
  https://www.java.com/en/download/help/error_hotspot.xml ([https](https://www.java.com/en/download/help/error_hotspot.xml) result 200).